### PR TITLE
Bug fix: repair bad flush of AC

### DIFF
--- a/cpp/ArithmeticCoder.cpp
+++ b/cpp/ArithmeticCoder.cpp
@@ -147,8 +147,11 @@ void ArithmeticEncoder::write(const FrequencyTable &freqs, uint32_t symbol) {
 
 
 void ArithmeticEncoder::finish() {
-	shift();
-	output.write(1);
+	numUnderflow++;
+	bool bit = static_cast<bool>(low >= quarterRange);
+	output.write(bit);
+	for (; numUnderflow > 0; numUnderflow--)
+		output.write(!bit);
 }
 
 

--- a/cpp/ArithmeticCoder.cpp
+++ b/cpp/ArithmeticCoder.cpp
@@ -147,6 +147,7 @@ void ArithmeticEncoder::write(const FrequencyTable &freqs, uint32_t symbol) {
 
 
 void ArithmeticEncoder::finish() {
+	shift();
 	output.write(1);
 }
 


### PR DESCRIPTION
Hi all, thanks for this lib.

When I am running ac of C++ implement, I found the finish() function a bit of tricky. Specifically, It should have flush all the pending bits (or overflow bits as you named it) but it just write a terminating "1".

Here is how to reproducing it:

```cpp
#include <bits/stdc++.h>
using namespace std;
class BitStream {
  public:
    BitStream(){ m_pos = 0; }
    ~BitStream(){}
    void push_back(bool value){
        if(m_pos%8==0){
            bitset<8> tmp;
            m_data.push_back(tmp);
        }
        m_data[m_pos/8].set(m_pos%8, value);
        m_pos++;

    }
    void set(int pos, bool value){
        assert(pos < m_pos);
        m_data[pos/8].set(pos%8, value);
    }
    bool get(int pos){
        assert(pos < m_pos);
        return m_data[pos/8][pos%8];
    }
    int size(){ return m_pos; }
  private:
    vector<bitset<8>> m_data;
    int m_pos;
};

class ACEncoder {
  public:
    BitStream bit_stream;
    ACEncoder(int precision){
        assert(precision>=1&&precision<=63);
        _precision = precision;
    	_full_range = static_cast<uint64_t>(1) << _precision;
        _half_range = _full_range >> 1;
        _quarter_range = _half_range >> 1;
        _min_range = _quarter_range + 2;
        _max_total = std::min(std::numeric_limits<uint64_t>::max() / _full_range, _min_range);
        _mask = _full_range - 1;
        _low = 0;
        _high = _mask;
        _pending_bits=0;
    }
    ~ACEncoder(){}
    void encode(uint32_t &sym, vector<uint32_t> cdf){
        assert(_low < _high);
        assert((_low & _mask) == _low);
        assert((_high & _mask) == _high);
        uint64_t range = _high - _low + 1;
        assert(_min_range <= range);
        assert(range <= _full_range);
        uint32_t c_total = cdf[cdf.size() - 1];
        uint32_t c_low = cdf[sym];
        uint32_t c_high = cdf[sym + 1];
        assert(c_low!=c_high);
        assert(c_total<=_max_total);
        uint64_t n_low  = _low + c_low  * range / c_total;
        uint64_t n_high = _low + c_high * range / c_total - 1;
        _low = n_low;
        _high = n_high;
        while (((_low ^ _high) & _half_range) == 0) {
            shift();
            _low  = ((_low  << 1) & _mask);
            _high = ((_high << 1) & _mask) | 1;
        }
        while ((_low & ~_high & _quarter_range) != 0) {
            assert(_pending_bits < std::numeric_limits<uint64_t>::max());
            _pending_bits++;
            _low = (_low << 1) ^ _half_range;
            _high = ((_high ^ _half_range) << 1) | _half_range | 1;
        }
    }
    void shift(){
        int bit = static_cast<int>(_low >> (_precision - 1));
        bit_stream.push_back(bit);        
        for (; _pending_bits > 0; _pending_bits--)
            bit_stream.push_back(bit ^ 1);
    }
  private:
    int _precision;
    uint64_t _full_range;
    uint64_t _half_range;
    uint64_t _quarter_range;
    uint64_t _min_range;
    uint64_t _max_total;
    uint64_t _mask;
    uint64_t _low;
    uint64_t _high;
    uint64_t _pending_bits;
};

int main(){
    ACEncoder ace=ACEncoder(32);
    uint32_t symbol = 0; // 0, 1, 2, 3, 4
    uint32_t cdf_max=(1<<16)-1;
    // 5 categorical dist with 20% prob each symbol
    vector<uint32_t> cdf = {0, 0.2 * cdf_max, 0.4 * cdf_max, 0.6 * cdf_max, 0.8 * cdf_max, cdf_max}; //
    ace.encode(symbol,cdf);
    ace.encode(symbol,cdf);
    ace.encode(symbol,cdf);
    ace.encode(symbol,cdf);
    ace.encode(symbol,cdf);
    ace.encode(symbol,cdf);
    ace.encode(symbol,cdf);
    ace.encode(symbol,cdf);
    ace.encode(symbol,cdf);
    printf("%d\n",ace.bit_stream.size());
}
```
Excuse me for using my own interface. I am really trying to make it minimal and runnable with a single file.

By the end of the exe of main function, the number of bits in the bitstream is "1", however, the number of bits to be flushed in the "_pending_bits" or "numUnderflow" is "19", which does  not sounds like usual.

After calling "shift" as a flush / finish operation, the actual bits goes to 22, which is normal.

P.S. I have not check the Java / Python impl